### PR TITLE
update schema to current version

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "moment": "^2.10.6",
     "pm2": "^0.15.7",
     "rc": "~0.5.0",
-    "removals_schema": "ukhomeoffice/removals_schema#RELEASE/0.1.0",
+    "removals_schema": "ukhomeoffice/removals_schema#RELEASE/0.1.2",
     "sails": "~0.11.0",
     "sails-disk": "~0.10.0",
     "tv4": "^1.2.7"


### PR DESCRIPTION
BM-248 Require a reason for intersite moves
BM-247 Explicitly record if a bed is out of commission due to a single occupancy requirement
