### PR TITLE
BM-396: BE: root controller with json api compliant link to /centres

### DIFF
--- a/api/controllers/RootController.js
+++ b/api/controllers/RootController.js
@@ -1,0 +1,8 @@
+'use strict';
+
+module.exports = {
+  index: (req, res) => {
+    res.links.centres = '/centres';
+    return res.ok();
+  }
+};

--- a/api/responses/ok.js
+++ b/api/responses/ok.js
@@ -17,6 +17,7 @@ module.exports = function sendOK(data, options) {
   var req = this.req;
   var res = this.res;
   var sails = req._sails;
+  var links = res.links;
 
   sails.log.silly('res.ok() :: Sending 200 ("OK") response');
 
@@ -25,9 +26,9 @@ module.exports = function sendOK(data, options) {
 
   // If appropriate, serve data as JSON(P)
   var JSONresponse = {
-    links: {
+    links: _.extend({
       self: req.baseUrl + req.url
-    },
+    }, links),
     data: data
   };
   return res.jsonx(JSONresponse);

--- a/config/routes.js
+++ b/config/routes.js
@@ -20,4 +20,6 @@
  * http://sailsjs.org/#/documentation/concepts/Routes/RouteTargetSyntax.html
  */
 
-module.exports.routes = {}
+module.exports.routes = {
+  'get /': 'RootController.index'
+}

--- a/test/unit/controllers/RootController.test.js
+++ b/test/unit/controllers/RootController.test.js
@@ -1,0 +1,15 @@
+'use strict';
+
+describe('INTEGRATION RootController', () =>
+  it('should be able to get the root page', () =>
+    request(sails.hooks.http.app)
+      .get('/')
+      .expect(200)
+      .expect(res => {
+        expect(res.body.links)
+          .to.have.property('centres')
+          .and.equal('/centres')
+
+      })
+  )
+);


### PR DESCRIPTION
- add route for '/'
- add RootController to handle new route
- render index template on GET /