### PR TITLE
IBM-229 Inter site transfer reconciliation publication flakey

### DIFF
--- a/api/controllers/Depmu_EntryController.js
+++ b/api/controllers/Depmu_EntryController.js
@@ -90,7 +90,7 @@ module.exports = {
       .tap(this.truncatePrebookings)
       .map(this.prebookingProcess)
       .tap(this.updateReceivedDate)
-      .tap(Centres.publishCentreUpdates)
+      .tap(Centres.publishUpdateAll)
       .then(res.ok)
       .catch(ValidationError, error => res.badRequest(error.result.errors[0].message))
       .catch(RangeError, error => res.unprocessableEntity(error))

--- a/test/unit/controllers/CentreController.test.js
+++ b/test/unit/controllers/CentreController.test.js
@@ -7,7 +7,7 @@ Scenario('INTEGRATION CentreController', () => {
     var centre;
 
     beforeEach(() => Centres.create({name: _.uniqueId("test")})
-        .then(newcentre => centre = newcentre)
+      .then(newcentre => centre = newcentre)
     );
 
     afterEach(() => centre.destroy());
@@ -17,41 +17,41 @@ Scenario('INTEGRATION CentreController', () => {
         .get('/centres')
         .expect(200)
         .expect(res => {
-          expect(res.body.data)
-            .to.have.length.at.least(3)
+            expect(res.body.data)
+              .to.have.length.at.least(3)
 
-          expect(res.body.data)
-            .to.contain.a.thing.with.property('id', centre.id.toString())
-            .and.to.contain.a.thing.with.property('attributes')
+            expect(res.body.data)
+              .to.contain.a.thing.with.property('id', centre.id.toString())
+              .and.to.contain.a.thing.with.property('attributes')
 
-        }
-      ));
+          }
+        ));
 
     it('should be able to add a new centre', () =>
-        request_auth(sails.hooks.http.app)
-          .post('/centres')
-          .send()
-          .expect(201)
-          .expect(res => expect(res.body).to.have.property('id'))
-          .toPromise()
-          .tap(res => Centres.destroy(res.body.id))
+      request_auth(sails.hooks.http.app)
+        .post('/centres')
+        .send()
+        .expect(201)
+        .expect(res => expect(res.body).to.have.property('id'))
+        .toPromise()
+        .tap(res => Centres.destroy(res.body.id))
     );
 
     it('should be able to update an existing centre', () =>
-        request_auth(sails.hooks.http.app)
-          .put('/centres/' + centre.id)
-          .send({male_capacity: 10})
-          .expect(200)
-          .then(() => Centres.findOne(centre.id))
-          .then(centre => expect(centre).to.have.property('male_capacity', 10))
+      request_auth(sails.hooks.http.app)
+        .put('/centres/' + centre.id)
+        .send({male_capacity: 10})
+        .expect(200)
+        .then(() => Centres.findOne(centre.id))
+        .then(centre => expect(centre).to.have.property('male_capacity', 10))
     );
 
     it('should be able to delete an existing centre', () =>
-        request_auth(sails.hooks.http.app)
-          .del('/centres/' + centre.id)
-          .expect(200)
-          .then(() => Centres.findOne(centre.id))
-          .then(centre => expect(centre).to.be.empty)
+      request_auth(sails.hooks.http.app)
+        .del('/centres/' + centre.id)
+        .expect(200)
+        .then(() => Centres.findOne(centre.id))
+        .then(centre => expect(centre).to.be.empty)
     );
   }
 );
@@ -59,20 +59,20 @@ Scenario('INTEGRATION CentreController', () => {
 describe('INTEGRATION CentreController Schema checks', () => {
 
   it('should provide valid output for a centre', () =>
-      request(sails.hooks.http.app)
-        .get('/centres/1')
-        .expect(200)
-        .then(response =>
-          expect(validator.isValid(response.body)).to.be.true
+    request(sails.hooks.http.app)
+      .get('/centres/1')
+      .expect(200)
+      .then(response =>
+        expect(validator.isValid(response.body)).to.be.true
       )
   );
 
   it('should provide valid output for centres', () =>
-      request(sails.hooks.http.app)
-        .get('/centres')
-        .expect(200)
-        .then(response =>
-          expect(validator.isValid(response.body)).to.be.true
+    request(sails.hooks.http.app)
+      .get('/centres')
+      .expect(200)
+      .then(response =>
+        expect(validator.isValid(response.body)).to.be.true
       )
   );
 });

--- a/test/unit/controllers/Depmu_EntryController.test.js
+++ b/test/unit/controllers/Depmu_EntryController.test.js
@@ -171,7 +171,7 @@ describe('UNIT Depmu_EntryController', () => {
       gender: 'male',
       active: true
     };
-    
+
     it('should filter movements without a populated detainee', () =>
       Movement.create(dummyMovement)
         .then(() => controller.filterPrebookingsWithNoMovementOrder(dummyPrebooking))
@@ -242,12 +242,12 @@ describe('UNIT Depmu_EntryController', () => {
         prebookingProcess: sinon.spy(controller, 'prebookingProcess'),
         updateReceivedDate: sinon.spy(controller, 'updateReceivedDate')
       };
-      sinon.stub(Centres, 'publishCentreUpdates').resolves();
+      sinon.stub(Centres, 'publishUpdateAll').resolves();
     });
 
     afterEach(() => {
       global.DepmuEntryPrebookingValidatorService = validationservice;
-      Centres.publishCentreUpdates.restore();
+      Centres.publishUpdateAll.restore();
       context.formatPrebooking.restore();
       context.populatePrebookingWithContingency.restore();
       context.populatePrebookingWithCentreAndGender.restore();

--- a/test/unit/controllers/Irc_EntryController.test.js
+++ b/test/unit/controllers/Irc_EntryController.test.js
@@ -40,13 +40,13 @@ describe('INTEGRATION Irc_EntryController', () => {
     });
 
     it('should handle UPDATE operation', () => {
-      const detainee = { centre: { id: {} } };
+      const detainee = {centre: {id: {}}};
       const processEventDetaineeStub = sinon.stub().resolves(detainee);
-      const publishCentreUpdatesStub = sinon.stub().resolves(detainee);
+      const publishCentreUpdatesStub = sinon.stub(Centres, 'publishUpdateOne').resolves(true);
 
       const restores = [];
       restores.push(controller.__set__('processEventDetainee', processEventDetaineeStub));
-      restores.push(controller.__set__('publishCentreUpdates', publishCentreUpdatesStub));
+      restores.push(publishCentreUpdatesStub.restore);
 
       const request_body = {
         operation: Event.OPERATION_UPDATE
@@ -72,10 +72,10 @@ describe('INTEGRATION Irc_EntryController', () => {
       const eventStubReturnValue = {
         centre: {}
       };
-      const publishCentreUpdatesStub = sinon.stub().resolves(detainee);
+
+      const publishCentreUpdatesStub = sinon.stub(Centres, 'publishUpdateOne').resolves(true);
       const processDetaineeStub = sinon.stub().resolves(detainee);
       const EventCreateStub = sinon.stub().resolves(eventStubReturnValue);
-
       const request_body = {
         operation: Event.OPERATION_CHECK_IN,
         timestamp: new Date()
@@ -84,10 +84,9 @@ describe('INTEGRATION Irc_EntryController', () => {
       const restores = [];
       restores.push(controller.__set__('processEventDetainee', processDetaineeStub));
       restores.push(controller.__set__('Event.create', EventCreateStub));
-      restores.push(controller.__set__('publishCentreUpdates', publishCentreUpdatesStub));
+      restores.push(publishCentreUpdatesStub.restore);
 
       const result = controller.process_event(request_body);
-
 
       return result.then((result) => {
         expect(processDetaineeStub.calledWith(request_body)).to.equal(true);
@@ -114,7 +113,7 @@ describe('INTEGRATION Irc_EntryController', () => {
         }
       };
       const processDetaineeStub = sinon.stub().resolves(processDetaineeStubReturnValue);
-      const publishCentreUpdatesStub = sinon.stub().resolves(processDetaineeStubReturnValue);
+      const publishCentreUpdatesStub = sinon.stub(Centres, 'publishUpdateOne').resolves(true);
       const eventStubReturnValue = {
         centre: {}
       };
@@ -127,11 +126,10 @@ describe('INTEGRATION Irc_EntryController', () => {
 
       const restores = [];
       restores.push(controller.__set__('processEventDetainee', processDetaineeStub));
-      restores.push(controller.__set__('publishCentreUpdates', publishCentreUpdatesStub));
+      restores.push(publishCentreUpdatesStub.restore);
       restores.push(controller.__set__('Event.create', EventCreateStub));
 
       const result = controller.process_event(request_body);
-
 
       return result.then((result) => {
         expect(processDetaineeStub.calledWith(request_body)).to.equal(true);
@@ -164,7 +162,7 @@ describe('INTEGRATION Irc_EntryController', () => {
       };
       const processDetaineeStub = sinon.stub().resolves(detainee);
       const EventCreateStub = sinon.stub().resolves(eventStubReturnValue);
-      const publishCentreUpdatesStub = sinon.stub().resolves(processDetaineeStubReturnValue);
+      const publishCentreUpdatesStub = sinon.stub(Centres, 'publishUpdateOne').resolves(true);
 
       const request_body = {
         operation: Event.OPERATION_REINSTATEMENT,
@@ -174,10 +172,9 @@ describe('INTEGRATION Irc_EntryController', () => {
       const restores = [];
       restores.push(controller.__set__('processEventDetainee', processDetaineeStub));
       restores.push(controller.__set__('Event.create', EventCreateStub));
-      restores.push(controller.__set__('publishCentreUpdates', publishCentreUpdatesStub));
+      restores.push(publishCentreUpdatesStub.restore);
 
       const result = controller.process_event(request_body);
-
 
       return result.then((result) => {
         expect(processDetaineeStub.calledWith(request_body)).to.equal(true);
@@ -273,7 +270,7 @@ describe('INTEGRATION Irc_EntryController', () => {
 
       controller.__get__('processEventDetainee')(request_body)
         .then((result) => {
-          expect(findOneStub.calledWith({ name: request_body.centre })).to.equal(true);
+          expect(findOneStub.calledWith({name: request_body.centre})).to.equal(true);
           expect(generateDetaineeStub.calledWith(centre, request_body)).to.equal(true);
           expect(result).to.deep.equal(createReturnValue);
         }).finally(() => {
@@ -384,7 +381,7 @@ describe('INTEGRATION Irc_EntryController', () => {
       });
       it('should create a new detainee', () => {
         const detaineeProperties = {
-          centre: { id: {} },
+          centre: {id: {}},
           person_id: {},
           somethingElse: {}
         };
@@ -419,7 +416,7 @@ describe('INTEGRATION Irc_EntryController', () => {
       });
       it('should update the detainee', () => {
         const detaineeProperties = {
-          centre: { id: {} },
+          centre: {id: {}},
           timestamp: (new Date('2016-05-02')).toISOString()
         };
         return expect(controller.__get__('createOrUpdateDetainee')(detaineeProperties)).to.eventually.equal(saveReturnValue);
@@ -442,7 +439,7 @@ describe('INTEGRATION Irc_EntryController', () => {
       });
       it('should return the found detainee', () => {
         const detaineeProperties = {
-          centre: { id: {} },
+          centre: {id: {}},
           timestamp: (new Date('2016-05-01')).toISOString()
         };
         return expect(controller.__get__('createOrUpdateDetainee')(detaineeProperties)).to.eventually.equal(dummyDetaineeRecord);
@@ -469,7 +466,7 @@ describe('INTEGRATION Irc_EntryController', () => {
 
       it('should be able to process update the centre with heartbeat information', () =>
         expect(controller.process_heartbeat(fake_json)
-          .then(() => Centres.findOne({ name: fake_json.centre })))
+          .then(() => Centres.findOne({name: fake_json.centre})))
           .to.eventually.contain({
           female_in_use: fake_json.female_occupied,
           female_out_of_commission: fake_json.female_outofcommission,
@@ -481,7 +478,7 @@ describe('INTEGRATION Irc_EntryController', () => {
         it('should update the centre heartbeat timestamp on processing an update', () =>
           expect(controller.process_heartbeat(fake_json)
             .then(() =>
-              Centres.findOne({ name: fake_json.centre })
+              Centres.findOne({name: fake_json.centre})
             ))
             .to.eventually.have.property('heartbeat_received')
             .and.be.a('date')
@@ -537,7 +534,7 @@ describe('INTEGRATION Irc_EntryController', () => {
 describe('UNIT Irc_EntryController', () => {
   describe('index', () => {
     it('should return res.ok', () =>
-      expect(controller.index(null, { ok: 'flo' })).to.eql('flo')
+      expect(controller.index(null, {ok: 'flo'})).to.eql('flo')
     );
   });
 
@@ -595,30 +592,6 @@ describe('UNIT Irc_EntryController', () => {
 
   });
 
-  describe('publishCentreUpdates', () => {
-    beforeEach(() => {
-      sinon.stub(Centres, 'find').returns(sinon.stub().resolves(true));
-      sinon.stub(BedCountService, 'performConfiguredReconciliation').resolves({
-        id: {},
-        toJSON: () => {}
-      })
-      sinon.stub(Centres, 'publishUpdate').resolves(sinon.stub().resolves(true));
-    });
-
-    afterEach(() => {
-      Centres.find.restore();
-      BedCountService.performConfiguredReconciliation.restore();
-      Centres.publishUpdate.restore();
-    });
-
-    var dummyMovement = [{ id: 1 }, { id: 2 }, { id: 3 }];
-    it('should eventually resolve with the movements', () =>
-      controller.__get__('publishCentreUpdates')(dummyMovement).then((result) => {
-        expect(result).to.equal(dummyMovement)
-      })
-    );
-  });
-
   describe('heartbeatOptions', () => {
     let validationservice;
     before(() => {
@@ -630,7 +603,7 @@ describe('UNIT Irc_EntryController', () => {
     after(() => global.IrcEntryHeartbeatValidatorService = validationservice);
 
     it('should return the schema', () => {
-      let res = { ok: sinon.stub() }
+      let res = {ok: sinon.stub()}
       controller.heartbeatOptions(null, res);
       expect(res.ok).to.be.calledWith('foobar');
     });
@@ -665,7 +638,7 @@ describe('UNIT Irc_EntryController', () => {
 
     it('should update the centre', () =>
       expect(global.Centres.update).to.be.calledWith(
-        { name: fake_request.centre },
+        {name: fake_request.centre},
         {
           heartbeat_received: new Date(),
           male_in_use: fake_request.male_occupied,


### PR DESCRIPTION
Turns out we had a bunch of different ways to publish updates.
I've now rationalised this all down to two (one for updating an individual centre, another for updating all)